### PR TITLE
domain API minimized by exposing essential methods only

### DIFF
--- a/src/lib/domain/decider.ts
+++ b/src/lib/domain/decider.ts
@@ -134,7 +134,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Sin - New input State
    */
-  protected mapLeftOnState<Sin>(
+  private mapLeftOnState<Sin>(
     f: (sin: Sin) => Si
   ): _Decider<C, Sin, So, Ei, Eo> {
     return this.dimapOnState(f, identity);
@@ -145,7 +145,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Son - New output State
    */
-  protected mapOnState<Son>(f: (so: So) => Son): _Decider<C, Si, Son, Ei, Eo> {
+  private mapOnState<Son>(f: (so: So) => Son): _Decider<C, Si, Son, Ei, Eo> {
     return this.dimapOnState(identity, f);
   }
 
@@ -154,7 +154,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Son - New output State
    */
-  protected applyOnState<Son>(
+  private applyOnState<Son>(
     ff: _Decider<C, Si, (so: So) => Son, Ei, Eo>
   ): _Decider<C, Si, Son, Ei, Eo> {
     return new _Decider(
@@ -169,7 +169,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Son - New output State
    */
-  protected productOnState<Son>(
+  private productOnState<Son>(
     fb: _Decider<C, Si, Son, Ei, Eo>
   ): _Decider<C, Si, readonly [So, Son], Ei, Eo> {
     return this.applyOnState(fb.mapOnState((b: Son) => (a: So) => [a, b]));

--- a/src/lib/domain/decider.ts
+++ b/src/lib/domain/decider.ts
@@ -113,24 +113,6 @@ export class _Decider<C, Si, So, Ei, Eo>
   }
 
   /**
-   * Left map on E/Event parameter - Contravariant
-   *
-   * @typeParam Ein - New input Event
-   */
-  mapLeftOnEvent<Ein>(f: (ein: Ein) => Ei): _Decider<C, Si, So, Ein, Eo> {
-    return this.dimapOnEvent(f, identity);
-  }
-
-  /**
-   * Right map on E/Event parameter - Covariant
-   *
-   * @typeParam Eon - New output Event
-   */
-  mapOnEvent<Eon>(f: (ein: Eo) => Eon): _Decider<C, Si, So, Ei, Eon> {
-    return this.dimapOnEvent(identity, f);
-  }
-
-  /**
    * Dimap on S/State parameter - Contravariant on input state (Si) and Covariant on output state (So) = Profunctor
    *
    * @typeParam Sin - New input State
@@ -152,7 +134,9 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Sin - New input State
    */
-  mapLeftOnState<Sin>(f: (sin: Sin) => Si): _Decider<C, Sin, So, Ei, Eo> {
+  protected mapLeftOnState<Sin>(
+    f: (sin: Sin) => Si
+  ): _Decider<C, Sin, So, Ei, Eo> {
     return this.dimapOnState(f, identity);
   }
 
@@ -161,7 +145,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Son - New output State
    */
-  mapOnState<Son>(f: (so: So) => Son): _Decider<C, Si, Son, Ei, Eo> {
+  protected mapOnState<Son>(f: (so: So) => Son): _Decider<C, Si, Son, Ei, Eo> {
     return this.dimapOnState(identity, f);
   }
 
@@ -170,7 +154,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Son - New output State
    */
-  applyOnState<Son>(
+  protected applyOnState<Son>(
     ff: _Decider<C, Si, (so: So) => Son, Ei, Eo>
   ): _Decider<C, Si, Son, Ei, Eo> {
     return new _Decider(
@@ -185,7 +169,7 @@ export class _Decider<C, Si, So, Ei, Eo>
    *
    * @typeParam Son - New output State
    */
-  productOnState<Son>(
+  protected productOnState<Son>(
     fb: _Decider<C, Si, Son, Ei, Eo>
   ): _Decider<C, Si, readonly [So, Son], Ei, Eo> {
     return this.applyOnState(fb.mapOnState((b: Son) => (a: So) => [a, b]));

--- a/src/lib/domain/view.ts
+++ b/src/lib/domain/view.ts
@@ -105,7 +105,7 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Sin - New input State
    */
-  protected mapLeftOnState<Sin>(f: (sin: Sin) => Si): _View<Sin, So, E> {
+  private mapLeftOnState<Sin>(f: (sin: Sin) => Si): _View<Sin, So, E> {
     return this.dimapOnState(f, identity);
   }
 
@@ -114,7 +114,7 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Son - New output State
    */
-  protected mapOnState<Son>(f: (so: So) => Son): _View<Si, Son, E> {
+  private mapOnState<Son>(f: (so: So) => Son): _View<Si, Son, E> {
     return this.dimapOnState(identity, f);
   }
 
@@ -123,7 +123,7 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Son - New output State
    */
-  protected applyOnState<Son>(
+  private applyOnState<Son>(
     ff: _View<Si, (so: So) => Son, E>
   ): _View<Si, Son, E> {
     return new _View(
@@ -137,7 +137,7 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Son - New output State
    */
-  protected productOnState<Son>(
+  private productOnState<Son>(
     fb: _View<Si, Son, E>
   ): _View<Si, readonly [So, Son], E> {
     return this.applyOnState(fb.mapOnState((b: Son) => (a: So) => [a, b]));

--- a/src/lib/domain/view.ts
+++ b/src/lib/domain/view.ts
@@ -105,7 +105,7 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Sin - New input State
    */
-  mapLeftOnState<Sin>(f: (sin: Sin) => Si): _View<Sin, So, E> {
+  protected mapLeftOnState<Sin>(f: (sin: Sin) => Si): _View<Sin, So, E> {
     return this.dimapOnState(f, identity);
   }
 
@@ -114,7 +114,7 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Son - New output State
    */
-  mapOnState<Son>(f: (so: So) => Son): _View<Si, Son, E> {
+  protected mapOnState<Son>(f: (so: So) => Son): _View<Si, Son, E> {
     return this.dimapOnState(identity, f);
   }
 
@@ -123,7 +123,9 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Son - New output State
    */
-  applyOnState<Son>(ff: _View<Si, (so: So) => Son, E>): _View<Si, Son, E> {
+  protected applyOnState<Son>(
+    ff: _View<Si, (so: So) => Son, E>
+  ): _View<Si, Son, E> {
     return new _View(
       (s: Si, e: E) => ff.evolve(s, e)(this.evolve(s, e)),
       ff.initialState(this.initialState)
@@ -135,7 +137,9 @@ export class _View<Si, So, E> implements I_View<Si, So, E> {
    *
    * @typeParam Son - New output State
    */
-  productOnState<Son>(fb: _View<Si, Son, E>): _View<Si, readonly [So, Son], E> {
+  protected productOnState<Son>(
+    fb: _View<Si, Son, E>
+  ): _View<Si, readonly [So, Son], E> {
     return this.applyOnState(fb.mapOnState((b: Son) => (a: So) => [a, b]));
   }
 


### PR DESCRIPTION
Removing some of the methods on the Decider and View classes that we find confusing and not needed at this point in time. 
