### PR TITLE
Application Event Repository Simplified - API changed

### DIFF
--- a/src/lib/application/eventsourcing-aggregate.spec.ts
+++ b/src/lib/application/eventsourcing-aggregate.spec.ts
@@ -229,12 +229,12 @@ class EventRepositoryLockingImpl2
 
   async save(
     e: EvenNumberEvt,
-    latestVersion: readonly [EvenNumberEvt, number] | null
+    latestVersion: number | null
   ): Promise<readonly [EvenNumberEvt, number]> {
     // eslint-disable-next-line functional/no-let
     let version;
     if (latestVersion) {
-      version = latestVersion[1];
+      version = latestVersion;
     } else version = 0;
 
     lockingStorage2.concat([e, version + 1]);
@@ -243,12 +243,12 @@ class EventRepositoryLockingImpl2
 
   async saveAll(
     eList: readonly EvenNumberEvt[],
-    latestVersion: readonly [EvenNumberEvt, number] | null
+    latestVersion: number | null
   ): Promise<readonly (readonly [EvenNumberEvt, number])[]> {
     // eslint-disable-next-line functional/no-let
     let version: number;
     if (latestVersion) {
-      version = latestVersion[1];
+      version = latestVersion;
     } else version = 0;
 
     const savedEvents: readonly (readonly [EvenNumberEvt, number])[] =
@@ -258,7 +258,8 @@ class EventRepositoryLockingImpl2
   }
 
   readonly latestVersionProvider: LatestVersionProvider<EvenNumberEvt, number> =
-    (_: EvenNumberEvt) => lockingStorage2[lockingStorage2.length - 1];
+    (_: EvenNumberEvt) =>
+      lockingStorage2.map((it) => it[1])[lockingStorage2.length - 1];
 
   async saveByLatestVersionProvided(
     e: EvenNumberEvt,
@@ -268,7 +269,7 @@ class EventRepositoryLockingImpl2
     // eslint-disable-next-line functional/no-let
     let version;
     if (latestVersion) {
-      version = latestVersion[1];
+      version = latestVersion;
     } else version = 0;
 
     lockingStorage2.concat([e, version + 1]);
@@ -280,7 +281,7 @@ class EventRepositoryLockingImpl2
     latestVersionProvider: LatestVersionProvider<EvenNumberEvt, number>
   ): Promise<readonly (readonly [EvenNumberEvt, number])[]> {
     const savedEvents: readonly (readonly [EvenNumberEvt, number])[] =
-      eList.map((e, index) => [e, latestVersionProvider(e)[1] + index + 1]);
+      eList.map((e, index) => [e, (latestVersionProvider(e) ?? 0) + index + 1]);
     lockingStorage2.concat(savedEvents);
     return savedEvents;
   }

--- a/src/lib/application/eventsourcing-aggregate.ts
+++ b/src/lib/application/eventsourcing-aggregate.ts
@@ -230,13 +230,10 @@ export class EventSourcingLockingAggregate<C, S, E, V>
   }
 
   readonly fetchEvents: (c: C) => Promise<readonly (readonly [E, V])[]>;
-  readonly save: (
-    e: E,
-    latestVersion: readonly [E, V] | null
-  ) => Promise<readonly [E, V]>;
+  readonly save: (e: E, latestVersion: V | null) => Promise<readonly [E, V]>;
   readonly saveAll: (
     eList: readonly E[],
-    latestVersion: readonly [E, V] | null
+    latestVersion: V | null
   ) => Promise<readonly (readonly [E, V])[]>;
   readonly saveByLatestVersionProvided: (
     e: E,
@@ -256,7 +253,7 @@ export class EventSourcingLockingAggregate<C, S, E, V>
         currentEvents.map((a) => a[0]),
         command
       ),
-      currentEvents[currentEvents.length - 1]
+      currentEvents.map((a) => a[1])[currentEvents.length - 1]
     );
   }
 }
@@ -342,13 +339,10 @@ export class EventSourcingOrchestratingLockingAggregate<C, S, E, V>
   }
 
   readonly fetchEvents: (c: C) => Promise<readonly (readonly [E, V])[]>;
-  readonly save: (
-    e: E,
-    latestVersion: readonly [E, V] | null
-  ) => Promise<readonly [E, V]>;
+  readonly save: (e: E, latestVersion: V | null) => Promise<readonly [E, V]>;
   readonly saveAll: (
     eList: readonly E[],
-    latestVersion: readonly [E, V] | null
+    latestVersion: V | null
   ) => Promise<readonly (readonly [E, V])[]>;
   readonly saveByLatestVersionProvided: (
     e: E,
@@ -408,7 +402,7 @@ export interface EventRepository<C, E> {
   readonly saveAll: (eList: readonly E[]) => Promise<readonly E[]>;
 }
 
-export type LatestVersionProvider<E, V> = (e: E) => readonly [E, V];
+export type LatestVersionProvider<E, V> = (e: E) => V | null;
 
 /**
  * Event Locking repository interface
@@ -435,10 +429,7 @@ export interface EventLockingRepository<C, E, V> {
    * @param latestVersion - Latest Event in this stream and its Version
    * @return  a pair of newly saved Event of type `E` and its Version of type `V`
    */
-  readonly save: (
-    e: E,
-    latestVersion: readonly [E, V] | null
-  ) => Promise<readonly [E, V]>;
+  readonly save: (e: E, latestVersion: V | null) => Promise<readonly [E, V]>;
 
   /**
    * Save events
@@ -449,7 +440,7 @@ export interface EventLockingRepository<C, E, V> {
    */
   readonly saveAll: (
     eList: readonly E[],
-    latestVersion: readonly [E, V] | null
+    latestVersion: V | null
   ) => Promise<readonly (readonly [E, V])[]>;
 
   /**


### PR DESCRIPTION
`EventLockingRepository` API is changed:

- `readonly save: (e: E, latestVersion: V | null) => Promise<readonly [E, V]>;` has the latest version parameter of type `V` now. It was a Pair of `E` and `V` previously. 
- `type LatestVersionProvider<E, V> = (e: E) => V | null;` is returning `V` now. It was a Pair of `E` and `V` previously. 