### PR TITLE
bind this to latestVersionProvider

### DIFF
--- a/src/lib/application/eventsourcing-aggregate.spec.ts
+++ b/src/lib/application/eventsourcing-aggregate.spec.ts
@@ -29,7 +29,7 @@ import {
   IEventSourcingLockingAggregate,
   IEventSourcingOrchestratingAggregate,
   IEventSourcingOrchestratingLockingAggregate,
-  LatestVersionProvider
+  LatestVersionProvider,
 } from './eventsourcing-aggregate';
 
 // ################################

--- a/src/lib/application/eventsourcing-aggregate.spec.ts
+++ b/src/lib/application/eventsourcing-aggregate.spec.ts
@@ -24,10 +24,12 @@ import {
   EventSourcingAggregate,
   EventSourcingLockingAggregate,
   EventSourcingOrchestratingAggregate,
+  EventSourcingOrchestratingLockingAggregate,
   IEventSourcingAggregate,
   IEventSourcingLockingAggregate,
   IEventSourcingOrchestratingAggregate,
-  LatestVersionProvider,
+  IEventSourcingOrchestratingLockingAggregate,
+  LatestVersionProvider
 } from './eventsourcing-aggregate';
 
 // ################################
@@ -383,6 +385,18 @@ const aggregate4: IEventSourcingOrchestratingAggregate<
   OddNumberEvt | EvenNumberEvt
 >(decider.combine(decider2), repository3, saga);
 
+const aggregateLocking4: IEventSourcingOrchestratingLockingAggregate<
+  EvenNumberCmd | OddNumberCmd,
+  readonly [number, number],
+  OddNumberEvt | EvenNumberEvt,
+  number
+> = new EventSourcingOrchestratingLockingAggregate<
+  EvenNumberCmd | OddNumberCmd,
+  readonly [number, number],
+  OddNumberEvt | EvenNumberEvt,
+  number
+>(decider.combine(decider2), repositoryLocking2, saga);
+
 // ################################
 // ############ Tests #############
 // ################################
@@ -427,5 +441,12 @@ test('aggregate-handle6', async (t) => {
   t.deepEqual(await aggregate4.handle(new AddOddNumberCmd(7)), [
     new OddNumberAddedEvt(7),
     new EvenNumberAddedEvt(8),
+  ]);
+});
+
+test('aggregate-locking-handle6', async (t) => {
+  t.deepEqual(await aggregateLocking4.handle(new AddOddNumberCmd(7)), [
+    [new OddNumberAddedEvt(7), 1],
+    [new EvenNumberAddedEvt(8), 2],
   ]);
 });

--- a/src/lib/application/eventsourcing-aggregate.ts
+++ b/src/lib/application/eventsourcing-aggregate.ts
@@ -404,7 +404,7 @@ export class EventSourcingOrchestratingLockingAggregate<C, S, E, V>
         async (c: C) =>
           (await this.eventRepository.fetchEvents(c)).map((it) => it[0])
       ),
-      this.latestVersionProvider
+      this.latestVersionProvider.bind(this)
     );
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for EventSourcingOrchestratingLockingAggregate

- **What is the current behavior?** (You can also link to an open issue here)

```
 TypeError {
    message: 'Cannot read properties of undefined (reading \'eventRepository\')',
  }
```

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
