### PR TITLE
Introducing `combineAndIntersect` method on `Decider` and `View`

### DIFF
--- a/src/lib/domain/decider.spec.ts
+++ b/src/lib/domain/decider.spec.ts
@@ -87,9 +87,7 @@ const decider: Decider<OddNumberCmd, number, OddNumberEvt> = new Decider<
       return s * e.value;
     } else {
       const _: never = e;
-      console.log('Returning state 1: ' + s);
-      console.log('Never just happened in evolve function decider 1: ' + _);
-      console.log('Returning state 2: ' + s);
+      console.log('Never just happened in evolve function: ' + _);
       return s;
     }
   },
@@ -113,16 +111,13 @@ const decider2: Decider<EvenNumberCmd, number, EvenNumberEvt> = new Decider<
     }
   },
   (s, e) => {
-    console.log('S: ' + s + ', E: ' + e.value);
     if (e instanceof EvenNumberAddedEvt) {
-      console.log('EvenNumberAddedEvt: ' + e.value);
       return s + e.value;
     } else if (e instanceof EvenNumberMultiplied) {
-      console.log('EvenNumberMultiplied: ' + e);
       return s * e.value;
     } else {
       const _: never = e;
-      console.log('Never just happened in evolve function in decider 2 ' + _);
+      console.log('Never just happened in evolve function: ' + _);
       return s;
     }
   },
@@ -187,16 +182,13 @@ const decider4: Decider<EvenNumberCmd, EvenState, EvenNumberEvt> = new Decider<
     }
   },
   (s, e) => {
-    console.log('S: ' + s + ', E: ' + e.value);
     if (e instanceof EvenNumberAddedEvt) {
-      console.log('EvenNumberAddedEvt: ' + e.value);
       return { evenNumber: s.evenNumber + e.value };
     } else if (e instanceof EvenNumberMultiplied) {
-      console.log('EvenNumberMultiplied: ' + e);
       return { evenNumber: s.evenNumber * e.value };
     } else {
       const _: never = e;
-      console.log('Never just happened in evolve function in decider 2 ' + _);
+      console.log('Never just happened in evolve function: ' + _);
       return { evenNumber: s.evenNumber };
     }
   },

--- a/src/lib/domain/saga.ts
+++ b/src/lib/domain/saga.ts
@@ -33,21 +33,6 @@ export interface ISaga<AR, A> {
  * @typeParam AR - Action Result type
  * @typeParam A - Action type
  *
- * @example
- * ```typescript
- * const saga: Saga<OddNumberEvt, EvenNumberCmd> = new Saga<OddNumberEvt, EvenNumberCmd>(
- * (ar) => {
- *   if (ar instanceof OddNumberAddedEvt) {
- *      return [new AddEvenNumberCmd(ar.value + 1)];
- *    } else if (ar instanceof OddNumberMultipliedEvt) {
- *      return [new MultiplyEvenNumberCmd(ar.value + 1)];
- *    } else {
- *      const _: never = e;
- *      console.log('Never just happened in react function: ' + _);
- *      return [];
- *    }
- * });
- * ```
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 export class Saga<AR, A> implements ISaga<AR, A> {

--- a/src/lib/domain/view.spec.ts
+++ b/src/lib/domain/view.spec.ts
@@ -67,6 +67,50 @@ const view2: View<number, EvenNumberEvt> = new View<number, EvenNumberEvt>(
   0
 );
 
+type OddState = {
+  oddNumber: number;
+};
+const view3: View<OddState, OddNumberEvt> = new View<OddState, OddNumberEvt>(
+  (s, e) => {
+    if (e instanceof OddNumberAddedEvt) {
+      return { oddNumber: s.oddNumber + e.value };
+    } else if (e instanceof OddNumberMultiplied) {
+      return { oddNumber: s.oddNumber * e.value };
+    } else {
+      const _: never = e;
+      console.log('Returning state 1: ' + s);
+      console.log('Never just happened in evolve function decider 1: ' + _);
+      console.log('Returning state 2: ' + s);
+      return { oddNumber: s.oddNumber };
+    }
+  },
+  { oddNumber: 0 }
+);
+
+type EvenState = {
+  evenNumber: number;
+};
+const view4: View<EvenState, EvenNumberEvt> = new View<
+  EvenState,
+  EvenNumberEvt
+>(
+  (s, e) => {
+    console.log('S: ' + s + ', E: ' + e.value);
+    if (e instanceof EvenNumberAddedEvt) {
+      console.log('EvenNumberAddedEvt: ' + e.value);
+      return { evenNumber: s.evenNumber + e.value };
+    } else if (e instanceof EvenNumberMultiplied) {
+      console.log('EvenNumberMultiplied: ' + e);
+      return { evenNumber: s.evenNumber * e.value };
+    } else {
+      const _: never = e;
+      console.log('Never just happened in evolve function in decider 2 ' + _);
+      return { evenNumber: s.evenNumber };
+    }
+  },
+  { evenNumber: 0 }
+);
+
 test('view-evolve', (t) => {
   t.is(view.evolve(1, new OddNumberAddedEvt(1)), 2);
 });
@@ -94,5 +138,23 @@ test('view-combined-evolve2', (t) => {
   t.deepEqual(
     view.combine(view2).evolve([0, 0], new EvenNumberAddedEvt(2)),
     [0, 2]
+  );
+});
+
+test('view-combined-evolve3', (t) => {
+  t.deepEqual(
+    view3
+      .combineAndIntersect(view4)
+      .evolve({ evenNumber: 0, oddNumber: 0 }, new OddNumberAddedEvt(1)),
+    { evenNumber: 0, oddNumber: 1 }
+  );
+});
+
+test('view-combined-evolve4', (t) => {
+  t.deepEqual(
+    view3
+      .combineAndIntersect(view4)
+      .evolve({ evenNumber: 0, oddNumber: 0 }, new EvenNumberAddedEvt(2)),
+    { evenNumber: 2, oddNumber: 0 }
   );
 });


### PR DESCRIPTION
Combines state via intersection (S & S2). Check the alternative method `combine` which uses tuples to achieve a similar goal.

1. Flexibility: If you anticipate needing to access individual components of the combined state separately, using tuples might be more appropriate, as it allows you to maintain separate types for each component. However, if you primarily need to treat the combined state as a single entity with all properties accessible at once, intersections might be more suitable.

2. Readability: Consider which approach makes your code more readable and understandable to other developers who may be working with your codebase. Choose the approach that best communicates your intentions and the structure of your data.

3. Compatibility: Consider the compatibility of your chosen approach with other libraries, frameworks, or tools you're using in your TypeScript project. Some libraries or tools might work better with one approach over the other.

## Depricating `mapLeft*` methods

We are renaming the `mapLeftOnCommand`, `mapLeftOnEvent` to `mapContraOnCommand` and `mapContraOnEvent`