### PR TITLE
`combine` method is using `intersections`/`&`

### DIFF
--- a/src/lib/domain/decider.spec.ts
+++ b/src/lib/domain/decider.spec.ts
@@ -178,10 +178,10 @@ test('even-decider-evolve', (t) => {
   );
 });
 
-test('combined-decider-evolve', (t) => {
+test('combined-via-tuples-decider-evolve', (t) => {
   t.deepEqual(
     oddDecider
-      .combine(evenDecider)
+      .combineViaTuples(evenDecider)
       .evolve([{ oddNumber: 0 }, { evenNumber: 0 }], {
         kind: 'EvenNumberAddedEvt',
         value: 2,
@@ -190,19 +190,20 @@ test('combined-decider-evolve', (t) => {
   );
 });
 
-test('combined-decider-evolve-2', (t) => {
+test('combined-decider-evolve', (t) => {
   t.deepEqual(
-    oddDecider
-      .combine(evenDecider)
-      .evolve([{ oddNumber: 0 }, { evenNumber: 0 }], {
+    oddDecider.combine(evenDecider).evolve(
+      { oddNumber: 0, evenNumber: 0 },
+      {
         kind: 'OddNumberAddedEvt',
         value: 3,
-      }),
-    [{ oddNumber: 3 }, { evenNumber: 0 }]
+      }
+    ),
+    { oddNumber: 3, evenNumber: 0 }
   );
 });
 
-test('decider-decide', (t) => {
+test('odd-decider-decide', (t) => {
   t.deepEqual(
     oddDecider.decide(
       { kindOfCommand: 'AddOddNumberCmd', valueOfCommand: 1 },
@@ -212,7 +213,7 @@ test('decider-decide', (t) => {
   );
 });
 
-test('decider-decide-with-map', (t) => {
+test('odd-decider-decide-with-map', (t) => {
   t.deepEqual(
     oddDecider
       .mapContraOnCommand<OddNumberCmd | EvenNumberCmd>(
@@ -226,10 +227,10 @@ test('decider-decide-with-map', (t) => {
   );
 });
 
-test('combined-decider-decide', (t) => {
+test('combined-via-tuples-decider-decide', (t) => {
   t.deepEqual(
     oddDecider
-      .combine(evenDecider)
+      .combineViaTuples(evenDecider)
       .decide({ kindOfCommand: 'AddOddNumberCmd', valueOfCommand: 1 }, [
         { oddNumber: 0 },
         { evenNumber: 0 },
@@ -238,10 +239,10 @@ test('combined-decider-decide', (t) => {
   );
 });
 
-test('combined-decider-decide-2', (t) => {
+test('combined-decider-decide', (t) => {
   t.deepEqual(
     oddDecider
-      .combineAndIntersect(evenDecider)
+      .combine(evenDecider)
       .decide(
         { kindOfCommand: 'AddEvenNumberCmd', valueOfCommand: 2 },
         { evenNumber: 0, oddNumber: 0 }

--- a/src/lib/domain/decider.ts
+++ b/src/lib/domain/decider.ts
@@ -118,23 +118,11 @@ class _Decider<C, Si, So, Ei, Eo> {
 
   /**
    * Right product on S/State parameter - Applicative
-   * Combines state via tuple [So, Son]
+   * Combines state via intersection (So & Son)
    *
    * @typeParam Son - New output State
    */
-  productOnState<Son>(
-    fb: _Decider<C, Si, Son, Ei, Eo>
-  ): _Decider<C, Si, readonly [So, Son], Ei, Eo> {
-    return this.applyOnState(fb.mapOnState((b: Son) => (a: So) => [a, b]));
-  }
-
-  /**
-   * Right product on S/State parameter - Applicative
-   * Combines state via interception (So & Son)
-   *
-   * @typeParam Son - New output State
-   */
-  productAndIntersectOnState<Son extends object>(
+  productOnState<Son extends object>(
     fb: _Decider<C, Si, Son, Ei, Eo>
   ): _Decider<C, Si, So & Son, Ei, Eo> {
     return this.applyOnState(
@@ -145,11 +133,49 @@ class _Decider<C, Si, So, Ei, Eo> {
   }
 
   /**
+   * Right product on S/State parameter - Applicative
+   * Combines state via tuple [So, Son]
+   *
+   * @typeParam Son - New output State
+   */
+  productViaTuplesOnState<Son>(
+    fb: _Decider<C, Si, Son, Ei, Eo>
+  ): _Decider<C, Si, readonly [So, Son], Ei, Eo> {
+    return this.applyOnState(fb.mapOnState((b: Son) => (a: So) => [a, b]));
+  }
+
+  /**
+   * Combine Deciders into one big Decider
+   *
+   * The States/S are combined via `intersection`
+   */
+  combine<C2, Si2 extends object, So2 extends object, Ei2, Eo2>(
+    y: _Decider<C2, Si2, So2, Ei2, Eo2>
+  ): _Decider<C | C2, Si & Si2, So & So2, Ei | Ei2, Eo | Eo2> {
+    const deciderX = this.mapContraOnCommand<C | C2>((c) => c as C)
+      .mapContraOnState<Si & Si2>((sin) => sin as Si)
+      .dimapOnEvent<Ei | Ei2, Eo | Eo2>(
+        (ein) => ein as Ei,
+        (eo) => eo
+      );
+
+    const deciderY = y
+      .mapContraOnCommand<C | C2>((c) => c as C2)
+      .mapContraOnState<Si & Si2>((sin) => sin as Si2)
+      .dimapOnEvent<Ei | Ei2, Eo | Eo2>(
+        (ein) => ein as Ei2,
+        (eo2) => eo2
+      );
+
+    return deciderX.productOnState(deciderY);
+  }
+
+  /**
    * Combine Deciders into one big Decider
    *
    * The States/S are combined via `tuples`
    */
-  combine<C2, Si2, So2, Ei2, Eo2>(
+  combineViaTuples<C2, Si2, So2, Ei2, Eo2>(
     y: _Decider<C2, Si2, So2, Ei2, Eo2>
   ): _Decider<
     C | C2,
@@ -173,33 +199,7 @@ class _Decider<C, Si, So, Ei, Eo> {
         (eo2) => eo2
       );
 
-    return deciderX.productOnState(deciderY);
-  }
-
-  /**
-   * Combine Deciders into one big Decider
-   *
-   * The States/S are combined via `intersections`
-   */
-  combineAndIntersect<C2, Si2 extends object, So2 extends object, Ei2, Eo2>(
-    y: _Decider<C2, Si2, So2, Ei2, Eo2>
-  ): _Decider<C | C2, Si & Si2, So & So2, Ei | Ei2, Eo | Eo2> {
-    const deciderX = this.mapContraOnCommand<C | C2>((c) => c as C)
-      .mapContraOnState<Si & Si2>((sin) => sin as Si)
-      .dimapOnEvent<Ei | Ei2, Eo | Eo2>(
-        (ein) => ein as Ei,
-        (eo) => eo
-      );
-
-    const deciderY = y
-      .mapContraOnCommand<C | C2>((c) => c as C2)
-      .mapContraOnState<Si & Si2>((sin) => sin as Si2)
-      .dimapOnEvent<Ei | Ei2, Eo | Eo2>(
-        (ein) => ein as Ei2,
-        (eo2) => eo2
-      );
-
-    return deciderX.productAndIntersectOnState(deciderY);
+    return deciderX.productViaTuplesOnState(deciderY);
   }
 }
 
@@ -385,34 +385,10 @@ export class Decider<C, S, E> implements IDecider<C, S, E> {
   }
 
   /**
-   * Combine multiple Deciders into one Decider - Monoid
-   *
-   * State/S is combined via `tuples / [S, S2]`. Check alternative method `combineAndIntersect`
-   *
-   * Tuples are more straightforward and may be more suitable for simple cases,
-   * while intersections provide more flexibility and can handle more complex scenarios.
-   *
-   * 1. Flexibility: If you anticipate needing to access individual components of the combined state separately, using tuples might be more appropriate, as it allows you to maintain separate types for each component. However, if you primarily need to treat the combined state as a single entity with all properties accessible at once, intersections might be more suitable.
-   *
-   * 2. Readability: Consider which approach makes your code more readable and understandable to other developers who may be working with your codebase. Choose the approach that best communicates your intentions and the structure of your data.
-   *
-   * 3. Compatibility: Consider the compatibility of your chosen approach with other libraries, frameworks, or tools you're using in your TypeScript project. Some libraries or tools might work better with one approach over the other.
-   */
-  combine<C2, S2, E2>(
-    decider2: Decider<C2, S2, E2>
-  ): Decider<C | C2, readonly [S, S2], E | E2> {
-    return asDecider(
-      new _Decider(this.decide, this.evolve, this.initialState).combine(
-        new _Decider(decider2.decide, decider2.evolve, decider2.initialState)
-      )
-    );
-  }
-
-  /**
    * Combine multiple Deciders into one Decider  - Monoid
    *
-   * State/S is combined via `intersection / (S & S2)`. It only make sense if S ans S2 are objects, not primitives.
-   * Check alternative method `combine`
+   * State/S is combined via `intersection / (S & S2)`. It only makes sense if S ans S2 are objects, not primitives.
+   * Check alternative method `combineViaTuples`
    *
    * Intersections provide more flexibility and can handle more complex scenarios,
    * while tuples are more straightforward and may be more suitable for simple cases.
@@ -423,15 +399,39 @@ export class Decider<C, S, E> implements IDecider<C, S, E> {
    *
    * Compatibility: Consider the compatibility of your chosen approach with other libraries, frameworks, or tools you're using in your TypeScript project. Some libraries or tools might work better with one approach over the other.
    */
-  combineAndIntersect<C2, S2 extends object, E2>(
+  combine<C2, S2 extends object, E2>(
     decider2: Decider<C2, S2, E2>
   ): Decider<C | C2, S & S2, E | E2> {
+    return asDecider(
+      new _Decider(this.decide, this.evolve, this.initialState).combine(
+        new _Decider(decider2.decide, decider2.evolve, decider2.initialState)
+      )
+    );
+  }
+
+  /**
+   * Combine multiple Deciders into one Decider - Monoid
+   *
+   * State/S is combined via `tuples / [S, S2]`. Check alternative method `combine`
+   *
+   * Tuples are more straightforward and may be more suitable for simple cases,
+   * while intersections provide more flexibility and can handle more complex scenarios.
+   *
+   * 1. Flexibility: If you anticipate needing to access individual components of the combined state separately, using tuples might be more appropriate, as it allows you to maintain separate types for each component. However, if you primarily need to treat the combined state as a single entity with all properties accessible at once, intersections might be more suitable.
+   *
+   * 2. Readability: Consider which approach makes your code more readable and understandable to other developers who may be working with your codebase. Choose the approach that best communicates your intentions and the structure of your data.
+   *
+   * 3. Compatibility: Consider the compatibility of your chosen approach with other libraries, frameworks, or tools you're using in your TypeScript project. Some libraries or tools might work better with one approach over the other.
+   */
+  combineViaTuples<C2, S2, E2>(
+    decider2: Decider<C2, S2, E2>
+  ): Decider<C | C2, readonly [S, S2], E | E2> {
     return asDecider(
       new _Decider(
         this.decide,
         this.evolve,
         this.initialState
-      ).combineAndIntersect(
+      ).combineViaTuples(
         new _Decider(decider2.decide, decider2.evolve, decider2.initialState)
       )
     );

--- a/src/lib/domain/view.spec.ts
+++ b/src/lib/domain/view.spec.ts
@@ -137,22 +137,24 @@ test('even-view-evolve2', (t) => {
 
 test('combined-view-evolve', (t) => {
   t.deepEqual(
-    oddView.combine(evenView).evolve([{ oddState: 0 }, { evenState: 0 }], {
-      kind: 'OddNumberAddedEvt',
-      value: 1,
-    }),
-    [{ oddState: 1 }, { evenState: 0 }]
-  );
-});
-
-test('combined-and-intersected-view-evolve', (t) => {
-  t.deepEqual(
     oddView
-      .combineAndIntersect(evenView)
+      .combine(evenView)
       .evolve(
         { oddState: 0, evenState: 0 },
         { kind: 'OddNumberAddedEvt', value: 1 }
       ),
     { oddState: 1, evenState: 0 }
+  );
+});
+
+test('combined-via-tuples-view-evolve', (t) => {
+  t.deepEqual(
+    oddView
+      .combineViaTuples(evenView)
+      .evolve([{ oddState: 0 }, { evenState: 0 }], {
+        kind: 'OddNumberAddedEvt',
+        value: 1,
+      }),
+    [{ oddState: 1 }, { evenState: 0 }]
   );
 });


### PR DESCRIPTION

Tuples are more straightforward and may be more suitable for simple cases,
while intersections provide more flexibility and can handle more complex scenarios.

1. Flexibility: If you anticipate needing to access individual components of the combined state separately, using tuples might be more appropriate, as it allows you to maintain separate types for each component. However, if you primarily need to treat the combined state as a single entity with all properties accessible at once, intersections might be more suitable.

2. Readability: Consider which approach makes your code more readable and understandable to other developers who may be working with your codebase. Choose the approach that best communicates your intentions and the structure of your data.

3. Compatibility: Consider the compatibility of your chosen approach with other libraries, frameworks, or tools you're using in your TypeScript project. Some libraries or tools might work better with one approach over the other.
- the old `combine` method is renamed to `combineViaTuples`
- tests are improved

