### PR TITLE
Include `event metadata` as param in the version provider

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fraktalio/fmodel-ts",
+  "version": "2.0.1",
+  "exports": "./src/index.ts"
+}

--- a/src/lib/application/eventsourcing-aggregate.spec.ts
+++ b/src/lib/application/eventsourcing-aggregate.spec.ts
@@ -241,7 +241,7 @@ class EventRepositoryImpl
   async save(
     eList: readonly Evt[],
     commandMetadata: CmdMetadata,
-    versionProvider: (e: Evt) => Promise<Version | null>
+    versionProvider: (e: Evt & EvtMetadata) => Promise<Version | null>
   ): Promise<readonly (Evt & Version & EvtMetadata)[]> {
     //mapping the Commands metadata into Events metadata !!!
     const savedEvents: readonly (Evt & Version & EvtMetadata)[] =
@@ -249,7 +249,12 @@ class EventRepositoryImpl
         eList.map(async (e: Evt, index) => ({
           kind: e.kind,
           value: e.value,
-          version: ((await versionProvider(e))?.version ?? 0) + index + 1,
+          version:
+            ((
+              await versionProvider({ ...e, traceId: commandMetadata.traceId })
+            )?.version ?? 0) +
+            index +
+            1,
           traceId: commandMetadata.traceId,
         }))
       );
@@ -257,7 +262,7 @@ class EventRepositoryImpl
     return savedEvents;
   }
 
-  async versionProvider(_e: Evt): Promise<Version | null> {
+  async versionProvider(_e: Evt & EvtMetadata): Promise<Version | null> {
     return storage[storage.length - 1];
   }
 }

--- a/src/lib/application/eventsourcing-aggregate.ts
+++ b/src/lib/application/eventsourcing-aggregate.ts
@@ -40,24 +40,24 @@ export interface IEventRepository<C, E, V, CM, EM> {
   /**
    * Get the latest event stream version / sequence
    *
-   * @param event - Event of type `E`
+   * @param event - Event of type `E & EM`
    *
    * @return the latest version / sequence of the event stream that this event belongs to.
    */
-  readonly versionProvider: (event: E) => Promise<V | null>;
+  readonly versionProvider: (event: E & EM) => Promise<V | null>;
 
   /**
    * Save events
    *
    * @param events - list of Events
    * @param commandMetadata - Command Metadata of the command that initiated `events`
-   * @param versionProvider - A provider for the Latest Event in this stream and its Version/Sequence
+   * @param versionProvider - A provider for the stream Version/Sequence
    * @return  a list of newly saved Event(s) of type `E` with Version of type `V` and with Event Metadata of type `EM`
    */
   readonly save: (
     events: readonly E[],
     commandMetadata: CM,
-    versionProvider: (e: E) => Promise<V | null>
+    versionProvider: (e: E & EM) => Promise<V | null>
   ) => Promise<readonly (E & V & EM)[]>;
 }
 
@@ -228,14 +228,14 @@ export class EventSourcingAggregate<C, S, E, V, CM, EM>
     return this.eventRepository.fetch(command);
   }
 
-  async versionProvider(event: E): Promise<V | null> {
+  async versionProvider(event: E & EM): Promise<V | null> {
     return this.eventRepository.versionProvider(event);
   }
 
   async save(
     events: readonly E[],
     commandMetadata: CM,
-    versionProvider: (e: E) => Promise<V | null>
+    versionProvider: (e: E & EM) => Promise<V | null>
   ): Promise<readonly (E & V & EM)[]> {
     return this.eventRepository.save(events, commandMetadata, versionProvider);
   }
@@ -284,14 +284,14 @@ export class EventSourcingOrchestratingAggregate<C, S, E, V, CM, EM>
     return this.eventRepository.fetch(command);
   }
 
-  async versionProvider(event: E): Promise<V | null> {
+  async versionProvider(event: E & EM): Promise<V | null> {
     return this.eventRepository.versionProvider(event);
   }
 
   async save(
     events: readonly E[],
     commandMetadata: CM,
-    versionProvider: (e: E) => Promise<V | null>
+    versionProvider: (e: E & EM) => Promise<V | null>
   ): Promise<readonly (E & V & EM)[]> {
     return this.eventRepository.save(events, commandMetadata, versionProvider);
   }


### PR DESCRIPTION
Changing the `versionProvider` func type in the [eventsourcing-aggregate.ts](https://github.com/fraktalio/fmodel-ts/compare/feature/event-metadata-and-version-provider?expand=1#diff-aee60147f19d9e801efa787d2a830da341cdba8f289396a3b6d25dbc23df5be0) to receive event of type `E & EM`, so Event with Metadata.

Event Metadata was previously missing from this function type. It is a bug.

By adding EM/Event Metadata we make it easier to differentiate domain data (E/Event) and infra data (EM/EventMetadata), and make our domain data lighter and focus on business logic, without being affected by the technical concerns. 

