### PR TITLE
Feature/metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fraktalio/fmodel-ts",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fraktalio/fmodel-ts",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "Apache License, Version 2.0",
       "devDependencies": {
         "@ava/typescript": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fraktalio/fmodel-ts",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Functional domain modeling with TypeScript. Optimized for event sourcing and CQRS",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/application/eventsourcing-aggregate.spec.ts
+++ b/src/lib/application/eventsourcing-aggregate.spec.ts
@@ -234,35 +234,30 @@ type Evt = EvenNumberEvt | OddNumberEvt;
 class EventRepositoryImpl
   implements IEventRepository<Cmd, Evt, Version, CmdMetadata, EvtMetadata>
 {
-  async fetch(
-    _c: Cmd & CmdMetadata
-  ): Promise<readonly (Evt & Version & EvtMetadata)[]> {
-    console.log(
-      '######################### CmdMetadata.traceId = ' + _c.traceId
-    );
+  async fetch(_c: Cmd): Promise<readonly (Evt & Version & EvtMetadata)[]> {
     return storage;
   }
 
   async save(
-    eList: readonly [Evt, CmdMetadata][],
-    versionProvider: (e: Evt, cm: CmdMetadata) => Promise<Version | null>
+    eList: readonly Evt[],
+    commandMetadata: CmdMetadata,
+    versionProvider: (e: Evt) => Promise<Version | null>
   ): Promise<readonly (Evt & Version & EvtMetadata)[]> {
     //mapping the Commands metadata into Events metadata !!!
     const savedEvents: readonly (Evt & Version & EvtMetadata)[] =
       await Promise.all(
-        eList.map(async (e, index) => ({
-          kind: e[0].kind,
-          value: e[0].value,
-          version:
-            ((await versionProvider(e[0], e[1]))?.version ?? 0) + index + 1,
-          traceId: e[1].traceId,
+        eList.map(async (e: Evt, index) => ({
+          kind: e.kind,
+          value: e.value,
+          version: ((await versionProvider(e))?.version ?? 0) + index + 1,
+          traceId: commandMetadata.traceId,
         }))
       );
     storage.concat(savedEvents);
     return savedEvents;
   }
 
-  async versionProvider(_e: Evt, _cm: CmdMetadata): Promise<Version | null> {
+  async versionProvider(_e: Evt): Promise<Version | null> {
     return storage[storage.length - 1];
   }
 }

--- a/src/lib/application/materialized-view.ts
+++ b/src/lib/application/materialized-view.ts
@@ -29,11 +29,11 @@ export interface IViewStateRepository<E, S, V, EM> {
   /**
    * Fetch state
    *
-   * @param event - Event of type `E` with metadata of type `EM`
+   * @param event - Event of type `E`
    *
    * @return current state / `S` with version / `V`, or NULL
    */
-  readonly fetch: (event: E & EM) => Promise<(S & V) | null>;
+  readonly fetch: (event: E) => Promise<(S & V) | null>;
   /**
    * Save state
    *
@@ -98,7 +98,7 @@ export class MaterializedView<S, E, V, EM>
     return this.view.evolve(state, event);
   }
 
-  async fetch(event: E & EM): Promise<(S & V) | null> {
+  async fetch(event: E): Promise<(S & V) | null> {
     return this.viewStateRepository.fetch(event);
   }
 

--- a/src/lib/application/statestored-aggregate.ts
+++ b/src/lib/application/statestored-aggregate.ts
@@ -31,10 +31,10 @@ export interface IStateRepository<C, S, V, CM, SM> {
   /**
    * Fetch state, version and metadata
    *
-   * @param command - Command payload of type C with metadata of type `CM`
+   * @param command - Command payload of type C
    * @return current State/[S], Version/[V] and State Metadata/[SM]
    */
-  readonly fetch: (command: C & CM) => Promise<(S & V & SM) | null>;
+  readonly fetch: (command: C) => Promise<(S & V & SM) | null>;
 
   /**
    * Save state (with optimistic locking)
@@ -176,7 +176,7 @@ export class StateStoredAggregate<C, S, E, V, CM, SM>
   ) {
     super(decider);
   }
-  async fetch(command: C & CM): Promise<(S & V & SM) | null> {
+  async fetch(command: C): Promise<(S & V & SM) | null> {
     return this.stateRepository.fetch(command);
   }
 
@@ -230,7 +230,7 @@ export class StateStoredOrchestratingAggregate<C, S, E, V, CM, SM>
     super(decider, saga);
   }
 
-  async fetch(command: C & CM): Promise<(S & V & SM) | null> {
+  async fetch(command: C): Promise<(S & V & SM) | null> {
     return this.stateRepository.fetch(command);
   }
 


### PR DESCRIPTION
Lowering down the responsibility of the Metadata types in the Application layer.

For example, the EventRepository interface:

```kotlin
export interface IEventRepository<C, E, V, CM, EM> {
  /**
   * Fetch events
   *
   * @param command - Command of type `C`
   *
   * @return list of Events with Version and Event Metadata
   */
  readonly fetch: (command: C) => Promise<readonly (E & V & EM)[]>;

  /**
   * Get the event stream version / sequence
   *
   * @param event - Event of type `E`
   *
   * @return the version / sequence of the event stream that this event belongs to.
   */
  readonly versionProvider: (event: E & EM) => Promise<V | null>;

  /**
   * Save events
   *
   * @param events - list of Events
   * @param commandMetadata - Command Metadata of the command that initiated `events`
   * @param versionProvider - A provider for the Latest Event in this stream and its Version/Sequence
   * @return  a list of newly saved Event(s) of type `E` with Version of type `V` and with Event Metadata of type `EM`
   */
  readonly save: (
    events: readonly E[],
    commandMetadata: CM,
    versionProvider: (e: E) => Promise<V | null>
  ) => Promise<readonly (E & V & EM)[]>;
}
```

Old interface:

```kotlin
export interface IEventRepository<C, E, V, CM, EM> {
  /**
   * Fetch events
   *
   * @param command - Command of type `C` with metadata of type `CM`
   *
   * @return list of Events with Version and Event Metadata
   */
  readonly fetch: (command: C & CM) => Promise<readonly (E & V & EM)[]>;

  /**
   * Get the latest event stream version / sequence
   *
   * @param event - Event of type `E`
   *
   * @return the latest version / sequence of the event stream that this event belongs to.
   */
  readonly versionProvider: (event: E) => Promise<V | null>;

  /**
   * Save events
   *
   * @param events - list of Events
   * @param commandMetadata - Command Metadata of the command that initiated `events`
   * @param versionProvider - A provider for the Latest Event in this stream and its Version/Sequence
   * @return  a list of newly saved Event(s) of type `E` with Version of type `V` and with Event Metadata of type `EM`
   */
  readonly save: (
    events: readonly E[],
    commandMetadata: CM,
    versionProvider: (e: E) => Promise<V | null>
  ) => Promise<readonly (E & V & EM)[]>;
}
```

The interface used `CM` as the param of `fetch` method, and `EM` in the `versionProvider`. This could lead to problems, for example, the `C` lost the relation with the list of E/Events it produced, as `CM` could be used to identify the events it needs to fetch. 

The relation between:

 - C and the E/Events it can produce
 - E and the Commands we can trigger next
 - List of E and the S/state they can evolve to

is the concern of domain layer, not of the application layer. 



