### PR TITLE
IViewStateRepository can fetch the state by Event Metadata now.

### DIFF
--- a/src/lib/application/materialized-view.ts
+++ b/src/lib/application/materialized-view.ts
@@ -29,11 +29,11 @@ export interface IViewStateRepository<E, S, V, EM> {
   /**
    * Fetch state
    *
-   * @param event - Event of type `E`
+   * @param event - Event of type `E` with metadata of type `EM`
    *
    * @return current state / `S` with version / `V`, or NULL
    */
-  readonly fetch: (event: E) => Promise<(S & V) | null>;
+  readonly fetch: (event: E & EM) => Promise<(S & V) | null>;
   /**
    * Save state
    *
@@ -98,7 +98,7 @@ export class MaterializedView<S, E, V, EM>
     return this.view.evolve(state, event);
   }
 
-  async fetch(event: E): Promise<(S & V) | null> {
+  async fetch(event: E & EM): Promise<(S & V) | null> {
     return this.viewStateRepository.fetch(event);
   }
 


### PR DESCRIPTION
`IViewStateRepository` can now fetch the current state by Event Metadata as well:

```typescript
export interface IViewStateRepository<E, S, V, EM> {
  /**
   * Fetch state
   *
   * @param event - Event of type `E` with metadata of type `EM`
   *
   * @return current state / `S` with version / `V`, or NULL
   */
  readonly fetch: (event: E & EM) => Promise<(S & V) | null>;
  /**
   * Save state
   *
   * @param state - State and Event Metadata of type `S & EM`
   * @param eventMetadata - Event Metadata of type `EM`
   * @param version - State version of type `V | null`
   * @return newly saved State and Version of type `S` & `V`
   */
  readonly save: (
    state: S,
    eventMetadata: EM,
    version: V | null
  ) => Promise<S & V>;
}
```
